### PR TITLE
Replace react-toastify with sonner for toasts

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21,7 +21,7 @@
         "next-themes": "^0.2.1",
         "react": "^18",
         "react-dom": "^18",
-        "react-toastify": "^10.0.4",
+        "sonner": "^1.4.0",
         "tailwind-merge": "^2.2.1",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -3836,18 +3836,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
-    "node_modules/react-toastify": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.4.tgz",
-      "integrity": "sha512-etR3RgueY8pe88SA67wLm8rJmL1h+CLqUGHuAoNsseW35oTGJEri6eBTyaXnFKNQ80v/eO10hBYLgz036XRGgA==",
-      "dependencies": {
-        "clsx": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4165,6 +4153,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.4.0.tgz",
+      "integrity": "sha512-nvkTsIuOmi9e5Wz5If8ldasJjZNVfwiXYijBi2dbijvTQnQppvMcXTFNxL/NUFWlI2yJ1JX7TREDsg+gYm9WyA==",
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/source-map-js": {

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
     "next-themes": "^0.2.1",
     "react": "^18",
     "react-dom": "^18",
-    "react-toastify": "^10.0.4",
+    "sonner": "^1.4.0",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/app/src/components/ui/sonner.tsx
+++ b/app/src/components/ui/sonner.tsx
@@ -1,0 +1,29 @@
+import { useTheme } from "next-themes"
+import { Toaster as Sonner } from "sonner"
+
+type ToasterProps = React.ComponentProps<typeof Sonner>
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton:
+            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton:
+            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -1,11 +1,9 @@
 import { ThemeProvider } from "@/components/ThemeProvider";
+import { Toaster } from "@/components/ui/sonner";
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 
 import React from "react";
-
-import { ToastContainer } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
@@ -16,9 +14,7 @@ export default function App({ Component, pageProps }: AppProps) {
       disableTransitionOnChange
     >
       <Component {...pageProps} />
-      <ToastContainer
-        style={{ paddingTop: "env(safe-area-inset-top, 32px)" }}
-      />
+      <Toaster position="top-center" />
     </ThemeProvider>
   );
 }

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -3,13 +3,13 @@ import { useRouter } from "next/router";
 import Link from "next/link";
 
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
-import { toast } from "react-toastify";
 import { SendHorizonal, Plus, LogOut } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 
 import { useSupabase, useSupabaseConfig } from "@/utils/useSupabaseConfig";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 
 type ConversationMessage = {
   role: string;


### PR DESCRIPTION
Swapped out the react-toastify library with the sonner package across the app to standardize toast notifications. Integrated a new Toaster component that hooks into the theming system for customized styling. This change results in a more cohesive look and feel for the toasts and reduces the styling complexity by leveraging theme-based classNames. Removed react-toastify imports and styles accordingly.