### PR TITLE
feat: Integrate Conversation History into Sidebar

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/core": "^5.6.0",
         "@capacitor/ios": "^5.6.0",
         "@capacitor/preferences": "^5.0.7",
+        "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-popover": "^1.0.7",
         "@radix-ui/react-slot": "^1.0.2",
@@ -29,7 +30,8 @@
         "react-dom": "^18",
         "sonner": "^1.4.0",
         "tailwind-merge": "^2.2.1",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "vaul": "^0.9.0"
       },
       "devDependencies": {
         "@capacitor/cli": "^5.6.0",
@@ -983,6 +985,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz",
+      "integrity": "sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -6254,6 +6292,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/vaul": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-0.9.0.tgz",
+      "integrity": "sha512-bZSySGbAHiTXmZychprnX/dE0EsSige88xtyyL3/MCRbrFotRPQZo7UdydGXZWw+CKbNOw5Ow8gwAo93/nB/Cg==",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.0.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -16,6 +16,7 @@
     "@capacitor/core": "^5.6.0",
     "@capacitor/ios": "^5.6.0",
     "@capacitor/preferences": "^5.0.7",
+    "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-slot": "^1.0.2",
@@ -33,7 +34,8 @@
     "react-dom": "^18",
     "sonner": "^1.4.0",
     "tailwind-merge": "^2.2.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "vaul": "^0.9.0"
   },
   "devDependencies": {
     "@capacitor/cli": "^5.6.0",

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -2,26 +2,22 @@ import { SupabaseClient } from "@supabase/supabase-js";
 import { useEffect, useRef, useState } from "react";
 import ChatLog, { Message } from "./ChatLog";
 import LogoutButton from "./LogoutButton";
-import { Button } from "./ui/button";
-import { History } from "lucide-react";
 import { ThemeToggle } from "./ThemeToggle";
 import PromptForm from "./PromptForm";
 import { toast } from "sonner";
 import NewConversationButton from "./NewConversationButton";
-import ConversationHistory from "./ConversationHistory";
 import { NavMenu } from "./NavMenu";
 import {
   useQuery,
   useMutation,
-  useQueryClient,
 } from '@tanstack/react-query'
+import SideMenu from "./SideMenu";
 
 export default function Chat({
   supabaseClient,
 }: {
   supabaseClient: SupabaseClient;
 }) {
-  const queryClient = useQueryClient()
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -29,7 +25,6 @@ export default function Chat({
   const [messages, setMessages] = useState<Message[]>([]);
   const [conversationId, setConversationId] = useState<number | null>(null);
   const [waitingForResponse, setWaitingForResponse] = useState(false);
-  const [showConversationHistory, setShowConversationHistory] = useState(false);
   
   const sendMessageAndReceiveResponse = useMutation({
     mutationFn: async (userMessage: Message) => {
@@ -151,7 +146,12 @@ export default function Chat({
   return (
     <>
       <div className="h-24 bg-gradient-to-b from-background flex justify-between items-center fixed top-0 w-full"></div>
-
+      <div className="fixed flex space-x-4 top-4 left-4">
+          <SideMenu
+            supabaseClient={supabaseClient}
+            setConversationId={setConversationId}
+          />
+      </div>
       <div className="fixed flex space-x-4 top-4 right-4">
         <NavMenu>
           <LogoutButton supabaseClient={supabaseClient} />
@@ -160,34 +160,15 @@ export default function Chat({
               newConversation.mutate();
             }}
           />
-          <Button
-            size={"icon"}
-            className="rounded-full bg-muted/20 text-muted-foreground hover:bg-muted/40"
-            onClick={() => {
-              setShowConversationHistory(!showConversationHistory);
-            }}
-          >
-            <History size={20} />
-          </Button>
           <ThemeToggle />
         </NavMenu>
       </div>
 
       <div className="p-8 mt-12 mb-32">
-        {showConversationHistory ? (
-          <ConversationHistory
-            supabaseClient={supabaseClient}
-            handleClose={() => {
-              setShowConversationHistory(!showConversationHistory);
-            }}
-            setConversationId={setConversationId}
-          />
-        ) : (
-          <ChatLog
-            messages={messages}
-            waitingForResponse={waitingForResponse}
-          />
-        )}
+        <ChatLog
+          messages={messages}
+          waitingForResponse={waitingForResponse}
+        />
       </div>
 
       <div ref={bottomRef} />

--- a/app/src/components/ConversationHistory.tsx
+++ b/app/src/components/ConversationHistory.tsx
@@ -2,118 +2,116 @@ import React, { useEffect, useState } from 'react';
 import { SupabaseClient } from "@supabase/supabase-js";
 import { Trash, ArrowRight } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
-import { Button } from "./ui/button";
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import { Skeleton } from './ui/skeleton';
+import { range } from '@/utils/range';
+import { DrawerClose } from './ui/drawer';
 
 export interface Conversation {
-    id: number;
-    created_at: string;
+  id: number;
+  created_at: string;
 };
 
 export default function ConversationHistory({
-    supabaseClient,
-    handleClose,
-    setConversationId,
+  supabaseClient,
+  setConversationId,
 }: {
-    supabaseClient: SupabaseClient;
-    handleClose: () => void;
-    setConversationId: (id: number) => void;
+  supabaseClient: SupabaseClient;
+  setConversationId: (id: number) => void;
 }) {
-    const queryClient = useQueryClient();
-    
-    const deleteConversation = useMutation({
-        mutationFn: async (conversationId: number) => {
-            const allConversations = queryClient.getQueryData<Conversation[]>(['conversations']);
-            const conversationFound = allConversations?.some((conversation) => conversation.id === conversationId);
+  const queryClient = useQueryClient();
+  
+  const deleteConversation = useMutation({
+    mutationFn: async (conversationId: number) => {
+      const allConversations = queryClient.getQueryData<Conversation[]>(['conversations']);
+      const conversationFound = allConversations?.some((conversation) => conversation.id === conversationId);
 
-            if (!conversationFound) {
-                throw new Error("Not found");
-            }
-            
-            const { error } = await supabaseClient
-                .from("conversations")
-                .delete()
-                .eq("id", conversationId);
-            if (error) {
-                throw error;
-            }
-        },
-        onSuccess: () => {
-            toast.success("Conversation deleted");
-        },
-        onError: (error) => {
-            toast.error(`Error deleting conversation: ${error.message}`);
-        },
-        onSettled: async () => {
-            queryClient.invalidateQueries({
-                queryKey: ['conversations'],
-            });
-        },
-    });
-
-    const getAllConversations = useQuery({
+      if (!conversationFound) {
+        throw new Error("Not found");
+      }
+      
+      const { error } = await supabaseClient
+        .from("conversations")
+        .delete()
+        .eq("id", conversationId);
+      if (error) {
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      toast.success("Conversation deleted");
+    },
+    onError: (error) => {
+      toast.error(`Error deleting conversation: ${error.message}`);
+    },
+    onSettled: async () => {
+      queryClient.invalidateQueries({
         queryKey: ['conversations'],
-        queryFn: async () => {
-            const { data, error } = await supabaseClient
-                .from("conversations")
-                .select("id, created_at")
-                .order("created_at", { ascending: false });
-            if (error) {
-                throw error;
-            }
-            return data;
-        },
-    });
+      });
+    },
+  });
 
-    const formatDate = (dateString: string) => {
-        const date = new Date(dateString);
-        return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
-    };
+  const getAllConversations = useQuery({
+    queryKey: ['conversations'],
+    queryFn: async () => {
+      const { data, error } = await supabaseClient
+        .from("conversations")
+        .select("id, created_at")
+        .order("created_at", { ascending: false });
+      if (error) {
+        throw error;
+      }
+      return data;
+    },
+  });
 
-    return (
-        <div className="modal p-4 flex flex-col items-center justify-center">
-            <Button
-                onClick={() => handleClose()}
-                className="mb-6 bg-muted/20 hover:bg-muted/50  py-2 px-4"
-            >
-                Back to Chat
-            </Button>
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+  };
 
-            <AnimatePresence initial={false}>
-                {getAllConversations.data && getAllConversations.data.length > 0 ? (
-                    <div className="space-y-4">
-                        {getAllConversations.data.map((conversation) => (
-                            <motion.div
-                                key={conversation.id}
-                                className="card flex bg-muted/20 rounded-xl px-4 py-3 mb-2 shadow-sm"
-                                initial={{ opacity: 0 }}
-                                animate={{ opacity: 1 }}
-                                exit={{ opacity: 0 }}
-                            >
-                                <div className="flex flex-col justify-between">
-                                    <div>ID: {conversation.id}</div>
-                                    <div className="text-sm text-gray-500">Created: {formatDate(conversation.created_at)}</div>
-                                </div>
-                                <div className="flex flex-col justify-center items-center pl-10">
-                                    <ArrowRight
-                                        size={20}
-                                        onClick={() => {
-                                            setConversationId(conversation["id"]);
-                                            handleClose();
-                                        }}
-                                    />
-                                    <Trash className='mt-2' size={20} onClick={
-                                        () => {
-                                            deleteConversation.mutate(conversation.id);
-                                        }
-                                    }></Trash>
-                                </div>
-                            </motion.div>
-                        ))}
-                    </div>
-                ) :  <span>Loading...</span>}
-            </AnimatePresence>
-        </div>
-    );
+  return (
+    <AnimatePresence initial={false}>
+      <div className="space-y-4 overflow-auto max-h-[80vh] pr-2">
+        {getAllConversations.data && getAllConversations.data.length > 0 ? (
+            getAllConversations.data.map((conversation) => (
+              <motion.div
+                key={conversation.id}
+                className="card flex bg-muted/20 rounded-xl px-4 py-3 mb-2 shadow-sm"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+              >
+                <div className="flex flex-col justify-between">
+                  <div>ID: {conversation.id}</div>
+                  <div className="text-sm text-gray-500">Created: {formatDate(conversation.created_at)}</div>
+                </div>
+                <div className="flex flex-col justify-center items-center pl-10">
+                  <DrawerClose>
+                    <ArrowRight size={20} onClick={() => setConversationId(conversation["id"])} />
+                  </DrawerClose>
+                  <Trash className='mt-2' size={20} onClick={() => deleteConversation.mutate(conversation.id)} />
+                </div>
+              </motion.div>
+            ))
+        ) : range(6).map((i) => <ItemSkeleton key={i} />)}
+      </div>
+    </AnimatePresence>
+  );
 };
+
+function ItemSkeleton() {
+  return (
+    <Skeleton className="card flex bg-muted/20 rounded-xl px-4 py-3 mb-2 shadow-sm gap-8">
+      <div className="flex flex-col gap-2 justify-between">
+        <Skeleton className="w-[20vw] h-4" />
+        <Skeleton className="w-[20vw] h-4" />
+      </div>
+      <div className="flex flex-col justify-center gap-2 items-center ml-auto">
+        <Skeleton className="w-[20px] h-[20px]" />
+        <Skeleton className="w-[20px] h-[20px]" />
+      </div>
+    </Skeleton>
+  )
+}

--- a/app/src/components/SideMenu.tsx
+++ b/app/src/components/SideMenu.tsx
@@ -1,0 +1,43 @@
+import { Button } from "@/components/ui/button"
+import {
+  Drawer,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer"
+import { SupabaseClient } from "@supabase/supabase-js";
+import ConversationHistory from "./ConversationHistory";
+import { Sidebar } from "lucide-react";
+
+export default function SideMenu({
+    supabaseClient,
+    setConversationId,
+}: {
+    supabaseClient: SupabaseClient;
+    setConversationId: (id: number) => void;
+}) {
+  return (
+    <Drawer>
+      <DrawerTrigger asChild>
+        <Button variant="ghost" size="icon" className="hover:bg-muted hover:text-muted-foreground">
+          <Sidebar />
+        </Button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <div className="mx-auto w-full max-w-sm">
+          <DrawerHeader>
+            <DrawerTitle>History</DrawerTitle>
+          </DrawerHeader>
+          <DrawerFooter>
+            <ConversationHistory
+              supabaseClient={supabaseClient}
+              setConversationId={setConversationId}
+            />
+          </DrawerFooter>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/app/src/components/ui/drawer.tsx
+++ b/app/src/components/ui/drawer.tsx
@@ -1,0 +1,117 @@
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/utils/cnHelper"
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    direction="left"
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+)
+Drawer.displayName = "Drawer"
+
+const DrawerTrigger = DrawerPrimitive.Trigger
+
+const DrawerPortal = DrawerPrimitive.Portal
+
+const DrawerClose = DrawerPrimitive.Close
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/50", className)}
+    {...props}
+  />
+))
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-y-0 left-0 z-50 mr-24 flex h-full max-w-[400px] flex-row rounded-r-[10px] border bg-background",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <div className="my-auto mr-4 w-2 h-[100px] rounded-full bg-border" />
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+))
+DrawerContent.displayName = "DrawerContent"
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("grid gap-1.5 p-4 text-center", className)}
+    {...props}
+  />
+)
+DrawerHeader.displayName = "DrawerHeader"
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    {...props}
+  />
+)
+DrawerFooter.displayName = "DrawerFooter"
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/app/src/components/ui/skeleton.tsx
+++ b/app/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/utils/cnHelper"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/app/src/utils/range.ts
+++ b/app/src/utils/range.ts
@@ -1,0 +1,15 @@
+export const range = (
+  start: number,
+  end?: number,
+  step = 1
+) => {
+  let output = [];
+  if (typeof end === 'undefined') {
+    end = start;
+    start = 0;
+  }
+  for (let i = start; i < end; i += step) {
+    output.push(i);
+  }
+  return output;
+};


### PR DESCRIPTION
Moved the conversation history feature from a modal to a new, more accessible Sidebar component. This improves the UX by allowing users to easily toggle between conversation history and the chat interface without leaving the context of the chat. The change includes the removal of redundant code and the addition of new utilities for better loading state handling. This update aligns with modern design practices and streamlines user interactions.

known bug: scrollIntoView not firing when switching conversations