### PR TITLE
add mime type back to python script

### DIFF
--- a/scripts/python_recorder_client/main.py
+++ b/scripts/python_recorder_client/main.py
@@ -82,6 +82,7 @@ def store_sound(frames):
         response = requests.post(f'{get_base_url()}/functions/v1/process-audio', files=files, headers={
             'Authorization': f'Bearer {args.token}',
             'apikey': args.token,
+            'Content-Type': 'audio/wav,',
         }, timeout=540)
     logger.info(response.text)
 


### PR DESCRIPTION
This was removed in https://github.com/adamcohenhillel/ADeus/pull/53 but I believe we need it for supabase to be happy.


before:
```
2024-02-15 14:53:46,600 - AudioRecorder - DEBUG - Still not silent, continuing recording...                                                                  
2024-02-15 14:53:46,600 - AudioRecorder - INFO - Status: [ WAITING FOR SOUND ]                                                                               
2024-02-15 14:53:46,663 - AudioRecorder - INFO - Status: [     RECORDING     ]                                                                               
2024-02-15 14:53:46,955 - AudioRecorder - INFO - Unsupported Media Type                                                                                      
2024-02-15 14:53:50,695 - AudioRecorder - DEBUG - 4 seconds reached, checking for continued sound...                                                         
2024-02-15 14:53:50,695 - AudioRecorder - DEBUG - Store and sending wav.                                                                                     
2024-02-15 14:53:50,695 - AudioRecorder - DEBUG - Still not silent, continuing recording...                                                                  
2024-02-15 14:53:50,695 - AudioRecorder - INFO - Status: [ WAITING FOR SOUND ]                                                                               
2024-02-15 14:53:50,758 - AudioRecorder - INFO - Status: [     RECORDING     ]                                                                               
2024-02-15 14:53:51,073 - AudioRecorder - INFO - Unsupported Media Type   
```

after (unrelated error):
```
2024-02-15 14:56:54,647 - AudioRecorder - DEBUG - 4 seconds reached, checking for continued sound...
2024-02-15 14:56:54,648 - AudioRecorder - DEBUG - Store and sending wav.
2024-02-15 14:56:54,648 - AudioRecorder - DEBUG - Still not silent, continuing recording...
2024-02-15 14:56:54,649 - AudioRecorder - INFO - Status: [ WAITING FOR SOUND ] 
2024-02-15 14:56:54,714 - AudioRecorder - INFO - Status: [     RECORDING     ]                                                                                
2024-02-15 14:56:55,650 - AudioRecorder - INFO - {"error":"400 The audio file could not be decoded or its format is not supported."}
2024-02-15 14:56:58,742 - AudioRecorder - DEBUG - 4 seconds reached, checking for continued sound...
2024-02-15 14:56:58,743 - AudioRecorder - DEBUG - Store and sending wav.
2024-02-15 14:56:58,743 - AudioRecorder - DEBUG - Still not silent, continuing recording...
2024-02-15 14:56:58,743 - AudioRecorder - INFO - Status: [ WAITING FOR SOUND ] 
2024-02-15 14:56:58,805 - AudioRecorder - INFO - Status: [     RECORDING     ]                                                                                
2024-02-15 14:56:59,505 - AudioRecorder - INFO - {"error":"400 The audio file could not be decoded or its format is not supported."}
```