### PR TITLE
removed hardcoded soundcard

### DIFF
--- a/devices/raspizerow/main.cpp
+++ b/devices/raspizerow/main.cpp
@@ -299,7 +299,7 @@ int main(int argc, char* argv[])
     snd_pcm_format_t format = SND_PCM_FORMAT_S32_LE;
 
     // Open PCM device for recording
-    rc = snd_pcm_open(&capture_handle, "plughw:0", SND_PCM_STREAM_CAPTURE, 0);
+    rc = snd_pcm_open(&capture_handle, "default", SND_PCM_STREAM_CAPTURE, 0);
     assert(rc >= 0);
     if (rc < 0)
     {


### PR DESCRIPTION
Changing to default is supposed to pick the first sound card detected. Before the selection was hardcoded. 
