### PR TITLE
fix: preserve chat history on client refocus

### DIFF
--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -117,7 +117,6 @@ export default function Chat({
         }
         return data;
       } else {
-        setMessages([]);
         const { data, error } = await supabaseClient
           .from('conversations')
           .select('*')


### PR DESCRIPTION
Prevented clearing of message history in the chat component upon re-fetching data from the server. This change maintains chat context for users when the client refocuses, improving user experience and avoiding unnecessary data loss.