### PR TITLE
Add submit on Enter and new line on Shift+Enter

### DIFF
--- a/app/src/components/PromptForm.tsx
+++ b/app/src/components/PromptForm.tsx
@@ -15,6 +15,15 @@ export default function PromptForm({
   isDisabled: boolean;
   sendMessage: () => void;
 }) {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      if (entryData.trim() !== '') {
+        sendMessage();
+      }
+    }
+  };
+
   return (
     <div className="fixed bottom-3 flex w-full items-center justify-center">
       <div
@@ -35,6 +44,7 @@ export default function PromptForm({
               textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
             }
           }}
+          onKeyDown={handleKeyDown}
           disabled={isDisabled}
           placeholder="What is on your mind?"
         ></textarea>


### PR DESCRIPTION
**Description**

This pull request enhances the user experience of the PromptForm component by adding the following functionality:

**Submit on Enter**

- When the user presses the Enter key in the textarea, the form will be submitted.
- The sendMessage function will be called if the entryData is not empty (after trimming any whitespace).
- This allows users to quickly send their messages without having to click the send button.
- New line on Shift+Enter:
- When the user presses Shift+Enter in the textarea, a new line will be inserted.
- This enables users to add line breaks to their messages when needed.

**The changes include:**

- Added a new handleKeyDown function that listens for the onKeyDown event on the textarea.
- Modified the textarea to include the onKeyDown event handler.
- Updated the conditions for disabling the send button to ensure it is only enabled when entryData is not empty.
- These enhancements provide a more intuitive and efficient way for users to interact with the PromptForm component, allowing them to quickly submit their messages and add line breaks when necessary.

This functionality mirrors what is used on most interfaces including Claude and ChatGPT.

Please review the changes and provide any feedback or suggestions for improvement. Once approved, this pull request can be merged into the main branch.